### PR TITLE
Update pak-update.R

### DIFF
--- a/R/pak-update.R
+++ b/R/pak-update.R
@@ -37,7 +37,11 @@ pak_repo_metadata <- function(repo = NULL, stream = "auto") {
   url <- paste0(repo, "metadata.json")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
-  utils::download.file(url, tmp, mode = "wb", quiet = TRUE)
+
+  # utils::download.file(url, tmp, mode = "wb", quiet = TRUE  )
+
+  download_file(url, tmp , mode = "wb", quiet = TRUE ,  method = NULL    )
+
   df <- json$parse_file(tmp)
   meta <- do.call(rbind, lapply(df, as.data.frame, stringsAsFactors = FALSE))
   rver <- sub("R ", "", sapply(strsplit(meta$Built, ";"), "[[", 1))
@@ -112,7 +116,10 @@ pak_update <- function(
 
   url <- paste0(repo, me$os, "/", me$arch, "/", meta$File[cand])
   tgt <- file.path(tempdir(), meta$File[cand])
-  utils::download.file(url, tgt, mode = "wb")
+
+  # utils::download.file(url, tgt, mode = "wb"  )
+  download_file(url, tgt , mode = "wb",    method = NULL    )
+
 
   date <- get_built_date(meta$Built[cand])
   message("\nUpdating to version ", meta$Version[cand], " (", date, ")\n")


### PR DESCRIPTION
to let user pass some arguments (`method` argument in this case) to utils::download.file method whenever it needs to be called.  method such as  "wininet" / "libcurl" .  In this PR I suggested an override method download_file which checks environment variable `pak_ENV_download_file_method` if it is set. 
I suggest creating `get_env_safe` function to check environment  variable `pak_ENV_download_file_method` if not set go with "libcurl" as default argument value .  

get_env_safe <-function(key  , default = NULL ){
  try({
    default = Sys.getenv(key )
  })
  default
}


download_file<-function(url,
                        destfile ,
                        method = NULL  ,
                        quiet = FALSE,
                        mode = "w",
                        cacheOK = TRUE,
                        extra = getOption("download.file.extra"),
                        headers = NULL,
                        ...){

  if(is.null(method)){
    method = get_env_safe( "pak_ENV_download_file_method" , default = "libcurl" )
  }


  utils::download.file(url , destfile , method = method  , ...  )
}